### PR TITLE
Refactoring the code and correcting overscan on some gamelists

### DIFF
--- a/amiga/theme.xml
+++ b/amiga/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/amstradcpc/theme.xml
+++ b/amstradcpc/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/arcade/theme.xml
+++ b/arcade/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/arcadehack/theme.xml
+++ b/arcadehack/theme.xml
@@ -1,76 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
-
-<textlist name="gamelist">
-<selectorImagePath>./../_art/iconh.png</selectorImagePath>
-<selectedColor>8cc63f</selectedColor>
-<secondaryColor>ae16d3</secondaryColor>
-<fontPath>./../_art/horror.ttf</fontPath>
-<fontSize>0.028</fontSize>
-</textlist>
-
-<text name="md_description">
-<fontPath>./../_art/horror.ttf</fontPath>
-<fontSize>0.028</fontSize>
-</text>
-
-<text name="md_lbl_rating, md_lbl_players, md_lbl_genre, md_lbl_releasedate, md_lbl_playcount, md_lbl_lastplayed, md_lbl_developer, md_lbl_publisher, md_developer, md_publisher">
-<fontPath>./../_art/horror.ttf</fontPath>
-<fontSize>0.028</fontSize>
-</text>
-
-<text name="md_genre">
-<fontPath>./../_art/horror.ttf</fontPath>
-<fontSize>0.025</fontSize>
-<pos>0.80 0.488</pos>
-</text>
-
-<text name="md_playcount">
-<fontPath>./../_art/horror.ttf</fontPath>
-<fontSize>0.06</fontSize>
-<pos>0.87 0.518</pos>
-</text>
-
-<text name="md_players">
-<color>f0f0f095</color>
-<fontPath>./../_art/horror.ttf</fontPath>
-<fontSize>0.07</fontSize>
-<pos>0.91 0.266</pos>
-</text>
-
-<datetime name="md_releasedate, md_lastplayed">
-<fontPath>./../_art/horror.ttf</fontPath>
-<fontSize>0.028</fontSize>
-</datetime>
-
-<rating name="md_rating">
-<filledPath>./../_art/fullh.png</filledPath>
-</rating>
-
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/atari2600/theme.xml
+++ b/atari2600/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/atari5200/theme.xml
+++ b/atari5200/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/atari7800/theme.xml
+++ b/atari7800/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/atari800/theme.xml
+++ b/atari800/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/atarilynx/theme.xml
+++ b/atarilynx/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/atarist/theme.xml
+++ b/atarist/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/auto-allgames/theme.xml
+++ b/auto-allgames/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/auto-favorites/theme.xml
+++ b/auto-favorites/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/auto-lastplayed/theme.xml
+++ b/auto-lastplayed/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/c64/theme.xml
+++ b/c64/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/capcom/theme.xml
+++ b/capcom/theme.xml
@@ -1,76 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
-
-<textlist name="gamelist">
-<selectorImagePath>./../_art/iconh.png</selectorImagePath>
-<selectedColor>8cc63f</selectedColor>
-<secondaryColor>ae16d3</secondaryColor>
-<fontPath>./../_art/horror.ttf</fontPath>
-<fontSize>0.028</fontSize>
-</textlist>
-
-<text name="md_description">
-<fontPath>./../_art/horror.ttf</fontPath>
-<fontSize>0.028</fontSize>
-</text>
-
-<text name="md_lbl_rating, md_lbl_players, md_lbl_genre, md_lbl_releasedate, md_lbl_playcount, md_lbl_lastplayed, md_lbl_developer, md_lbl_publisher, md_developer, md_publisher">
-<fontPath>./../_art/horror.ttf</fontPath>
-<fontSize>0.028</fontSize>
-</text>
-
-<text name="md_genre">
-<fontPath>./../_art/horror.ttf</fontPath>
-<fontSize>0.025</fontSize>
-<pos>0.80 0.488</pos>
-</text>
-
-<text name="md_playcount">
-<fontPath>./../_art/horror.ttf</fontPath>
-<fontSize>0.06</fontSize>
-<pos>0.87 0.518</pos>
-</text>
-
-<text name="md_players">
-<color>f0f0f095</color>
-<fontPath>./../_art/horror.ttf</fontPath>
-<fontSize>0.07</fontSize>
-<pos>0.91 0.266</pos>
-</text>
-
-<datetime name="md_releasedate, md_lastplayed">
-<fontPath>./../_art/horror.ttf</fontPath>
-<fontSize>0.028</fontSize>
-</datetime>
-
-<rating name="md_rating">
-<filledPath>./../_art/fullh.png</filledPath>
-</rating>
-
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/colecovision/theme.xml
+++ b/colecovision/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/cps1/theme.xml
+++ b/cps1/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/cps2/theme.xml
+++ b/cps2/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/cps3/theme.xml
+++ b/cps3/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/custom-collections/theme.xml
+++ b/custom-collections/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/daphne/theme.xml
+++ b/daphne/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/dreamcast/theme.xml
+++ b/dreamcast/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/famicom/theme.xml
+++ b/famicom/theme.xml
@@ -1,6 +1,6 @@
 <theme>
 	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+	<include>./../theme_jp.xml</include>
 
 <view name="system">
  <image name="background_color" extra="true">
@@ -24,56 +24,6 @@
   <pos>0 0</pos>
   <size>1 1</size>
  </image>
-
-<textlist name="gamelist">
-<selectorImagePath>./../_art/iconj.png</selectorImagePath>
-<selectedColor>cccccc</selectedColor>
-<secondaryColor>808080</secondaryColor>
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.028</fontSize>
-</textlist>
-
-<text name="md_description">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.027</fontSize>
-</text>
-
-<text name="md_lbl_rating, md_lbl_players, md_lbl_genre, md_lbl_releasedate, md_lbl_playcount, md_lbl_lastplayed, md_lbl_developer, md_lbl_publisher, md_developer, md_publisher">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.026</fontSize>
-</text>
-
-<text name="md_lbl_genre">
-	<pos>0.754 0.50</pos>
-</text>
-
-<text name="md_genre">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.0235</fontSize>
-<pos>0.81 0.495</pos>
-</text>
-
-<text name="md_playcount">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.04</fontSize>
-<pos>0.89 0.518</pos>
-</text>
-
-<text name="md_players">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.05</fontSize>
-<pos>0.905 0.266</pos>
-</text>
-
-<datetime name="md_releasedate, md_lastplayed">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.026</fontSize>
-</datetime>
-
-<rating name="md_rating">
-<filledPath>./../_art/fullj.png</filledPath>
-</rating>
-
 </view>
 
 </theme>

--- a/fba/theme.xml
+++ b/fba/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/fds/theme.xml
+++ b/fds/theme.xml
@@ -1,6 +1,6 @@
 <theme>
 	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+	<include>./../theme_jp.xml</include>
 
 <view name="system">
  <image name="background_color" extra="true">
@@ -24,56 +24,6 @@
   <pos>0 0</pos>
   <size>1 1</size>
  </image>
-
-<textlist name="gamelist">
-<selectorImagePath>./../_art/iconj.png</selectorImagePath>
-<selectedColor>cccccc</selectedColor>
-<secondaryColor>808080</secondaryColor>
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.028</fontSize>
-</textlist>
-
-<text name="md_description">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.027</fontSize>
-</text>
-
-<text name="md_lbl_rating, md_lbl_players, md_lbl_genre, md_lbl_releasedate, md_lbl_playcount, md_lbl_lastplayed, md_lbl_developer, md_lbl_publisher, md_developer, md_publisher">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.026</fontSize>
-</text>
-
-<text name="md_lbl_genre">
-	<pos>0.754 0.50</pos>
-</text>
-
-<text name="md_genre">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.0235</fontSize>
-<pos>0.81 0.495</pos>
-</text>
-
-<text name="md_playcount">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.04</fontSize>
-<pos>0.89 0.518</pos>
-</text>
-
-<text name="md_players">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.05</fontSize>
-<pos>0.905 0.266</pos>
-</text>
-
-<datetime name="md_releasedate, md_lastplayed">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.026</fontSize>
-</datetime>
-
-<rating name="md_rating">
-<filledPath>./../_art/fullj.png</filledPath>
-</rating>
-
 </view>
 
 </theme>

--- a/gameandwatch/theme.xml
+++ b/gameandwatch/theme.xml
@@ -30,7 +30,6 @@
 <primaryColor>232323</primaryColor>
 <selectedColor>232323</selectedColor>
 <secondaryColor>535353</secondaryColor>
-<fontSize>0.028</fontSize>
 </textlist>
 
 <rating name="md_rating">

--- a/gamecube/theme.xml
+++ b/gamecube/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/gamegear/theme.xml
+++ b/gamegear/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/gamewizard/theme.xml
+++ b/gamewizard/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/gb/theme.xml
+++ b/gb/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/gba/theme.xml
+++ b/gba/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/gbc/theme.xml
+++ b/gbc/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/genesis/theme.xml
+++ b/genesis/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/intellivision/theme.xml
+++ b/intellivision/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/kodi/theme.xml
+++ b/kodi/theme.xml
@@ -1,66 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
-
-<text name="md_lbl_rating, md_lbl_players, md_lbl_genre, md_lbl_releasedate, md_lbl_playcount, md_lbl_lastplayed, md_lbl_developer, md_lbl_publisher, md_developer, md_publisher">
-<fontSize>0.026</fontSize>
-</text>
-
-<text name="md_lbl_genre">
-	<pos>0.754 1.50</pos>
-</text>
-
-<text name="md_genre">
-<fontSize>0.0235</fontSize>
-<pos>0.81 1.495</pos>
-</text>
-
-<text name="md_lbl_playcount">
-	<pos>0.775 1.525</pos>
-</text>
-
-<text name="md_playcount">
-<fontSize>0.04</fontSize>
-<pos>0.89 1.518</pos>
-</text>
-
-<text name="md_players">
-<fontSize>0.05</fontSize>
-<pos>0.905 0.266</pos>
-</text>
-
-<datetime name="md_releasedate, md_lastplayed">
-<fontSize>0.026</fontSize>
-</datetime>
-
-<rating name="md_rating">
-<filledPath>./../_art/empty.png</filledPath>
-<unfilledPath>./../_art/empty.png</unfilledPath>
-</rating>
-
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/mame/theme.xml
+++ b/mame/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/markiii/theme.xml
+++ b/markiii/theme.xml
@@ -1,6 +1,6 @@
 <theme>
 	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+	<include>./../theme_jp.xml</include>
 
 <view name="system">
  <image name="background_color" extra="true">
@@ -24,56 +24,6 @@
   <pos>0 0</pos>
   <size>1 1</size>
  </image>
-
-<textlist name="gamelist">
-<selectorImagePath>./../_art/iconj.png</selectorImagePath>
-<selectedColor>cccccc</selectedColor>
-<secondaryColor>808080</secondaryColor>
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.028</fontSize>
-</textlist>
-
-<text name="md_description">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.027</fontSize>
-</text>
-
-<text name="md_lbl_rating, md_lbl_players, md_lbl_genre, md_lbl_releasedate, md_lbl_playcount, md_lbl_lastplayed, md_lbl_developer, md_lbl_publisher, md_developer, md_publisher">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.026</fontSize>
-</text>
-
-<text name="md_lbl_genre">
-	<pos>0.754 0.50</pos>
-</text>
-
-<text name="md_genre">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.0235</fontSize>
-<pos>0.81 0.495</pos>
-</text>
-
-<text name="md_playcount">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.04</fontSize>
-<pos>0.89 0.518</pos>
-</text>
-
-<text name="md_players">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.05</fontSize>
-<pos>0.905 0.266</pos>
-</text>
-
-<datetime name="md_releasedate, md_lastplayed">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.026</fontSize>
-</datetime>
-
-<rating name="md_rating">
-<filledPath>./../_art/fullj.png</filledPath>
-</rating>
-
 </view>
 
 </theme>

--- a/mastersystem/theme.xml
+++ b/mastersystem/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/megadrive/theme.xml
+++ b/megadrive/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/megadrivej/theme.xml
+++ b/megadrivej/theme.xml
@@ -1,6 +1,6 @@
 <theme>
 	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+	<include>./../theme_jp.xml</include>
 
 <view name="system">
  <image name="background_color" extra="true">
@@ -24,56 +24,6 @@
   <pos>0 0</pos>
   <size>1 1</size>
  </image>
-
-<textlist name="gamelist">
-<selectorImagePath>./../_art/iconj.png</selectorImagePath>
-<selectedColor>cccccc</selectedColor>
-<secondaryColor>808080</secondaryColor>
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.028</fontSize>
-</textlist>
-
-<text name="md_description">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.027</fontSize>
-</text>
-
-<text name="md_lbl_rating, md_lbl_players, md_lbl_genre, md_lbl_releasedate, md_lbl_playcount, md_lbl_lastplayed, md_lbl_developer, md_lbl_publisher, md_developer, md_publisher">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.026</fontSize>
-</text>
-
-<text name="md_lbl_genre">
-	<pos>0.754 0.50</pos>
-</text>
-
-<text name="md_genre">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.0235</fontSize>
-<pos>0.81 0.495</pos>
-</text>
-
-<text name="md_playcount">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.04</fontSize>
-<pos>0.89 0.518</pos>
-</text>
-
-<text name="md_players">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.05</fontSize>
-<pos>0.905 0.266</pos>
-</text>
-
-<datetime name="md_releasedate, md_lastplayed">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.026</fontSize>
-</datetime>
-
-<rating name="md_rating">
-<filledPath>./../_art/fullj.png</filledPath>
-</rating>
-
 </view>
 
 </theme>

--- a/msx/theme.xml
+++ b/msx/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/msx2/theme.xml
+++ b/msx2/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/n64/theme.xml
+++ b/n64/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/nds/theme.xml
+++ b/nds/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/neogeo/theme.xml
+++ b/neogeo/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/neogeocd/theme.xml
+++ b/neogeocd/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/nes/theme.xml
+++ b/nes/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/nesh/theme.xml
+++ b/nesh/theme.xml
@@ -1,76 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
-
-<textlist name="gamelist">
-<selectorImagePath>./../_art/iconh.png</selectorImagePath>
-<selectedColor>8cc63f</selectedColor>
-<secondaryColor>ae16d3</secondaryColor>
-<fontPath>./../_art/horror.ttf</fontPath>
-<fontSize>0.028</fontSize>
-</textlist>
-
-<text name="md_description">
-<fontPath>./../_art/horror.ttf</fontPath>
-<fontSize>0.028</fontSize>
-</text>
-
-<text name="md_lbl_rating, md_lbl_players, md_lbl_genre, md_lbl_releasedate, md_lbl_playcount, md_lbl_lastplayed, md_lbl_developer, md_lbl_publisher, md_developer, md_publisher">
-<fontPath>./../_art/horror.ttf</fontPath>
-<fontSize>0.028</fontSize>
-</text>
-
-<text name="md_genre">
-<fontPath>./../_art/horror.ttf</fontPath>
-<fontSize>0.025</fontSize>
-<pos>0.80 0.488</pos>
-</text>
-
-<text name="md_playcount">
-<fontPath>./../_art/horror.ttf</fontPath>
-<fontSize>0.06</fontSize>
-<pos>0.87 0.518</pos>
-</text>
-
-<text name="md_players">
-<color>f0f0f095</color>
-<fontPath>./../_art/horror.ttf</fontPath>
-<fontSize>0.07</fontSize>
-<pos>0.91 0.266</pos>
-</text>
-
-<datetime name="md_releasedate, md_lastplayed">
-<fontPath>./../_art/horror.ttf</fontPath>
-<fontSize>0.028</fontSize>
-</datetime>
-
-<rating name="md_rating">
-<filledPath>./../_art/fullh.png</filledPath>
-</rating>
-
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/ngp/theme.xml
+++ b/ngp/theme.xml
@@ -1,6 +1,6 @@
 <theme>
 	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+	<include>./../theme_jp.xml</include>
 
 <view name="system">
  <image name="background_color" extra="true">
@@ -24,56 +24,6 @@
   <pos>0 0</pos>
   <size>1 1</size>
  </image>
-
-<textlist name="gamelist">
-<selectorImagePath>./../_art/iconj.png</selectorImagePath>
-<selectedColor>cccccc</selectedColor>
-<secondaryColor>808080</secondaryColor>
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.028</fontSize>
-</textlist>
-
-<text name="md_description">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.027</fontSize>
-</text>
-
-<text name="md_lbl_rating, md_lbl_players, md_lbl_genre, md_lbl_releasedate, md_lbl_playcount, md_lbl_lastplayed, md_lbl_developer, md_lbl_publisher, md_developer, md_publisher">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.026</fontSize>
-</text>
-
-<text name="md_lbl_genre">
-	<pos>0.754 0.50</pos>
-</text>
-
-<text name="md_genre">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.0235</fontSize>
-<pos>0.81 0.495</pos>
-</text>
-
-<text name="md_playcount">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.04</fontSize>
-<pos>0.89 0.518</pos>
-</text>
-
-<text name="md_players">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.05</fontSize>
-<pos>0.905 0.266</pos>
-</text>
-
-<datetime name="md_releasedate, md_lastplayed">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.026</fontSize>
-</datetime>
-
-<rating name="md_rating">
-<filledPath>./../_art/fullj.png</filledPath>
-</rating>
-
 </view>
 
 </theme>

--- a/ngpc/theme.xml
+++ b/ngpc/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/pc/theme.xml
+++ b/pc/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/pce-cd/theme.xml
+++ b/pce-cd/theme.xml
@@ -1,6 +1,6 @@
 <theme>
 	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+	<include>./../theme_jp.xml</include>
 
 <view name="system">
  <image name="background_color" extra="true">
@@ -24,56 +24,6 @@
   <pos>0 0</pos>
   <size>1 1</size>
  </image>
-
-<textlist name="gamelist">
-<selectorImagePath>./../_art/iconj.png</selectorImagePath>
-<selectedColor>cccccc</selectedColor>
-<secondaryColor>808080</secondaryColor>
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.028</fontSize>
-</textlist>
-
-<text name="md_description">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.027</fontSize>
-</text>
-
-<text name="md_lbl_rating, md_lbl_players, md_lbl_genre, md_lbl_releasedate, md_lbl_playcount, md_lbl_lastplayed, md_lbl_developer, md_lbl_publisher, md_developer, md_publisher">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.026</fontSize>
-</text>
-
-<text name="md_lbl_genre">
-	<pos>0.754 0.50</pos>
-</text>
-
-<text name="md_genre">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.0235</fontSize>
-<pos>0.81 0.495</pos>
-</text>
-
-<text name="md_playcount">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.04</fontSize>
-<pos>0.89 0.518</pos>
-</text>
-
-<text name="md_players">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.05</fontSize>
-<pos>0.905 0.266</pos>
-</text>
-
-<datetime name="md_releasedate, md_lastplayed">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.026</fontSize>
-</datetime>
-
-<rating name="md_rating">
-<filledPath>./../_art/fullj.png</filledPath>
-</rating>
-
 </view>
 
 </theme>

--- a/pcengine/theme.xml
+++ b/pcengine/theme.xml
@@ -1,6 +1,6 @@
 <theme>
 	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+	<include>./../theme_jp.xml</include>
 
 <view name="system">
  <image name="background_color" extra="true">
@@ -24,56 +24,6 @@
   <pos>0 0</pos>
   <size>1 1</size>
  </image>
-
-<textlist name="gamelist">
-<selectorImagePath>./../_art/iconj.png</selectorImagePath>
-<selectedColor>cccccc</selectedColor>
-<secondaryColor>808080</secondaryColor>
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.028</fontSize>
-</textlist>
-
-<text name="md_description">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.027</fontSize>
-</text>
-
-<text name="md_lbl_rating, md_lbl_players, md_lbl_genre, md_lbl_releasedate, md_lbl_playcount, md_lbl_lastplayed, md_lbl_developer, md_lbl_publisher, md_developer, md_publisher">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.026</fontSize>
-</text>
-
-<text name="md_lbl_genre">
-	<pos>0.754 0.50</pos>
-</text>
-
-<text name="md_genre">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.0235</fontSize>
-<pos>0.81 0.495</pos>
-</text>
-
-<text name="md_playcount">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.04</fontSize>
-<pos>0.89 0.518</pos>
-</text>
-
-<text name="md_players">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.05</fontSize>
-<pos>0.905 0.266</pos>
-</text>
-
-<datetime name="md_releasedate, md_lastplayed">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.026</fontSize>
-</datetime>
-
-<rating name="md_rating">
-<filledPath>./../_art/fullj.png</filledPath>
-</rating>
-
 </view>
 
 </theme>

--- a/ports/theme.xml
+++ b/ports/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/psp/theme.xml
+++ b/psp/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/psx/theme.xml
+++ b/psx/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/retropie/theme.xml
+++ b/retropie/theme.xml
@@ -1,66 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
-
-<text name="md_lbl_rating, md_lbl_players, md_lbl_genre, md_lbl_releasedate, md_lbl_playcount, md_lbl_lastplayed, md_lbl_developer, md_lbl_publisher, md_developer, md_publisher">
-<fontSize>0.026</fontSize>
-</text>
-
-<text name="md_lbl_genre">
-	<pos>0.754 1.50</pos>
-</text>
-
-<text name="md_genre">
-<fontSize>0.0235</fontSize>
-<pos>0.81 1.495</pos>
-</text>
-
-<text name="md_lbl_playcount">
-	<pos>0.775 1.525</pos>
-</text>
-
-<text name="md_playcount">
-<fontSize>0.04</fontSize>
-<pos>0.89 1.518</pos>
-</text>
-
-<text name="md_players">
-<fontSize>0.05</fontSize>
-<pos>0.905 0.266</pos>
-</text>
-
-<datetime name="md_releasedate, md_lastplayed">
-<fontSize>0.026</fontSize>
-</datetime>
-
-<rating name="md_rating">
-<filledPath>./../_art/empty.png</filledPath>
-<unfilledPath>./../_art/empty.png</unfilledPath>
-</rating>
-
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/saturn/theme.xml
+++ b/saturn/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/scummvm/theme.xml
+++ b/scummvm/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/sega/theme.xml
+++ b/sega/theme.xml
@@ -1,76 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
-
-<textlist name="gamelist">
-<selectorImagePath>./../_art/iconh.png</selectorImagePath>
-<selectedColor>8cc63f</selectedColor>
-<secondaryColor>ae16d3</secondaryColor>
-<fontPath>./../_art/horror.ttf</fontPath>
-<fontSize>0.028</fontSize>
-</textlist>
-
-<text name="md_description">
-<fontPath>./../_art/horror.ttf</fontPath>
-<fontSize>0.028</fontSize>
-</text>
-
-<text name="md_lbl_rating, md_lbl_players, md_lbl_genre, md_lbl_releasedate, md_lbl_playcount, md_lbl_lastplayed, md_lbl_developer, md_lbl_publisher, md_developer, md_publisher">
-<fontPath>./../_art/horror.ttf</fontPath>
-<fontSize>0.028</fontSize>
-</text>
-
-<text name="md_genre">
-<fontPath>./../_art/horror.ttf</fontPath>
-<fontSize>0.025</fontSize>
-<pos>0.80 0.488</pos>
-</text>
-
-<text name="md_playcount">
-<fontPath>./../_art/horror.ttf</fontPath>
-<fontSize>0.06</fontSize>
-<pos>0.87 0.518</pos>
-</text>
-
-<text name="md_players">
-<color>f0f0f095</color>
-<fontPath>./../_art/horror.ttf</fontPath>
-<fontSize>0.07</fontSize>
-<pos>0.91 0.266</pos>
-</text>
-
-<datetime name="md_releasedate, md_lastplayed">
-<fontPath>./../_art/horror.ttf</fontPath>
-<fontSize>0.028</fontSize>
-</datetime>
-
-<rating name="md_rating">
-<filledPath>./../_art/fullh.png</filledPath>
-</rating>
-
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/sega32x/theme.xml
+++ b/sega32x/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/segacd/theme.xml
+++ b/segacd/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/sfc/theme.xml
+++ b/sfc/theme.xml
@@ -1,6 +1,6 @@
 <theme>
 	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+	<include>./../theme_jp.xml</include>
 
 <view name="system">
  <image name="background_color" extra="true">
@@ -24,56 +24,6 @@
   <pos>0 0</pos>
   <size>1 1</size>
  </image>
-
-<textlist name="gamelist">
-<selectorImagePath>./../_art/iconj.png</selectorImagePath>
-<selectedColor>cccccc</selectedColor>
-<secondaryColor>808080</secondaryColor>
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.028</fontSize>
-</textlist>
-
-<text name="md_description">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.027</fontSize>
-</text>
-
-<text name="md_lbl_rating, md_lbl_players, md_lbl_genre, md_lbl_releasedate, md_lbl_playcount, md_lbl_lastplayed, md_lbl_developer, md_lbl_publisher, md_developer, md_publisher">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.026</fontSize>
-</text>
-
-<text name="md_lbl_genre">
-	<pos>0.754 0.50</pos>
-</text>
-
-<text name="md_genre">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.0235</fontSize>
-<pos>0.81 0.495</pos>
-</text>
-
-<text name="md_playcount">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.04</fontSize>
-<pos>0.89 0.518</pos>
-</text>
-
-<text name="md_players">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.05</fontSize>
-<pos>0.905 0.266</pos>
-</text>
-
-<datetime name="md_releasedate, md_lastplayed">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.026</fontSize>
-</datetime>
-
-<rating name="md_rating">
-<filledPath>./../_art/fullj.png</filledPath>
-</rating>
-
 </view>
 
 </theme>

--- a/sg-1000/theme.xml
+++ b/sg-1000/theme.xml
@@ -1,6 +1,6 @@
 <theme>
 	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+	<include>./../theme_jp.xml</include>
 
 <view name="system">
  <image name="background_color" extra="true">
@@ -24,56 +24,6 @@
   <pos>0 0</pos>
   <size>1 1</size>
  </image>
-
-<textlist name="gamelist">
-<selectorImagePath>./../_art/iconj.png</selectorImagePath>
-<selectedColor>cccccc</selectedColor>
-<secondaryColor>808080</secondaryColor>
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.028</fontSize>
-</textlist>
-
-<text name="md_description">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.027</fontSize>
-</text>
-
-<text name="md_lbl_rating, md_lbl_players, md_lbl_genre, md_lbl_releasedate, md_lbl_playcount, md_lbl_lastplayed, md_lbl_developer, md_lbl_publisher, md_developer, md_publisher">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.026</fontSize>
-</text>
-
-<text name="md_lbl_genre">
-	<pos>0.754 0.50</pos>
-</text>
-
-<text name="md_genre">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.0235</fontSize>
-<pos>0.81 0.495</pos>
-</text>
-
-<text name="md_playcount">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.04</fontSize>
-<pos>0.89 0.518</pos>
-</text>
-
-<text name="md_players">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.05</fontSize>
-<pos>0.905 0.266</pos>
-</text>
-
-<datetime name="md_releasedate, md_lastplayed">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.026</fontSize>
-</datetime>
-
-<rating name="md_rating">
-<filledPath>./../_art/fullj.png</filledPath>
-</rating>
-
 </view>
 
 </theme>

--- a/shmups/theme.xml
+++ b/shmups/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/snes/theme.xml
+++ b/snes/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/snesh/theme.xml
+++ b/snesh/theme.xml
@@ -1,76 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
-
-<textlist name="gamelist">
-<selectorImagePath>./../_art/iconh.png</selectorImagePath>
-<selectedColor>8cc63f</selectedColor>
-<secondaryColor>ae16d3</secondaryColor>
-<fontPath>./../_art/horror.ttf</fontPath>
-<fontSize>0.028</fontSize>
-</textlist>
-
-<text name="md_description">
-<fontPath>./../_art/horror.ttf</fontPath>
-<fontSize>0.028</fontSize>
-</text>
-
-<text name="md_lbl_rating, md_lbl_players, md_lbl_genre, md_lbl_releasedate, md_lbl_playcount, md_lbl_lastplayed, md_lbl_developer, md_lbl_publisher, md_developer, md_publisher">
-<fontPath>./../_art/horror.ttf</fontPath>
-<fontSize>0.028</fontSize>
-</text>
-
-<text name="md_genre">
-<fontPath>./../_art/horror.ttf</fontPath>
-<fontSize>0.025</fontSize>
-<pos>0.80 0.488</pos>
-</text>
-
-<text name="md_playcount">
-<fontPath>./../_art/horror.ttf</fontPath>
-<fontSize>0.06</fontSize>
-<pos>0.87 0.518</pos>
-</text>
-
-<text name="md_players">
-<color>f0f0f095</color>
-<fontPath>./../_art/horror.ttf</fontPath>
-<fontSize>0.07</fontSize>
-<pos>0.91 0.266</pos>
-</text>
-
-<datetime name="md_releasedate, md_lastplayed">
-<fontPath>./../_art/horror.ttf</fontPath>
-<fontSize>0.028</fontSize>
-</datetime>
-
-<rating name="md_rating">
-<filledPath>./../_art/fullh.png</filledPath>
-</rating>
-
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/snespal/theme.xml
+++ b/snespal/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/supergrafx/theme.xml
+++ b/supergrafx/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/template/theme.xml
+++ b/template/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/tg-cd/theme.xml
+++ b/tg-cd/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/tg16/theme.xml
+++ b/tg16/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/theme.xml
+++ b/theme.xml
@@ -12,312 +12,258 @@ font: comic.otf
 -->
 
 <theme>
+<formatVersion>4</formatVersion>
 
-	<formatVersion>4</formatVersion>
-	
-	<!-- Carousel (Hide white bar and number of games-->
+<!-- Carousel (Hide white bar and number of games-->
 <feature supported="carousel">
+  <view name="system">
+    <carousel name="systemcarousel">
+      <pos>0 0</pos>
+      <color>00000000</color>
+      <maxLogoCount>1</maxLogoCount>
+    </carousel>
 
-<view name="system">
-
-<carousel name="systemcarousel">
-	<pos>0 0</pos>
-	<color>00000000</color>
-	<maxLogoCount>1</maxLogoCount>
-</carousel>
-
-<text name="systemInfo">
-    <fontPath>./_art/comic.otf</fontPath>
-	<alignment>right</alignment>
-	<backgroundColor>00000000</backgroundColor>
-	<color>ffcc33</color>
-	<pos>0.010 0.943</pos>
-	<size>0.980 0.050</size>
-	<fontSize>0.025</fontSize>
-</text>
-
-</view>
+    <text name="systemInfo">
+      <fontPath>./_art/comic.otf</fontPath>
+      <alignment>right</alignment>
+      <backgroundColor>00000000</backgroundColor>
+      <color>ffcc33</color>
+      <pos>0.010 0.943</pos>
+      <size>0.980 0.050</size>
+      <fontSize>0.025</fontSize>
+    </text>
+  </view>
 </feature>
+
 <!-- Carousel -->
-
 <view name="system">
+  <image name="background">
+    <tile>true</tile>
+    <color>23232300</color>
+    <path>./_art/white.png</path>
+    <size>1 1</size>
+    <pos>0 0</pos>
+  </image>
 
-<image name="background">
-	<tile>true</tile>
-	<color>23232300</color>
-	<path>./_art/white.png</path>
-	<size>1 1</size>
-	<pos>0 0</pos>
-</image>
-
-<helpsystem name="help">
-    <textColor>ffcc33</textColor>
-    <iconColor>ffcc33</iconColor>
-    <fontPath>./_art/comic.otf</fontPath>
-    <fontSize>0.025</fontSize>
-</helpsystem>
+  <helpsystem name="help">
+      <textColor>ffcc33</textColor>
+      <iconColor>ffcc33</iconColor>
+      <fontPath>./_art/comic.otf</fontPath>
+      <fontSize>0.025</fontSize>
+  </helpsystem>
 </view>
-
 <view name="basic, detailed, grid, video">
+  <image name="background">
+    <tile>true</tile>
+    <color>232323</color>
+    <path>./_art/white.png</path>
+    <size>1 1</size>
+    <pos>0 0</pos>
+    <zIndex>1</zIndex>
+  </image>
 
-<image name="background">
-	<tile>true</tile>
-	<color>232323</color>
-	<path>./_art/white.png</path>
-	<size>1 1</size>
-	<pos>0 0</pos>
-	<zIndex>1</zIndex>
-</image>
-
-<helpsystem name="help">
-	<pos>.007 1.936</pos>
-    <textColor>00000000</textColor>
-    <iconColor>00000000</iconColor>
-    <fontPath>./_art/comic.otf</fontPath>
-    <fontSize>0.016</fontSize>
-</helpsystem>
-
+  <helpsystem name="help">
+    <pos>.007 1.936</pos>
+       <textColor>00000000</textColor>
+       <iconColor>00000000</iconColor>
+       <fontPath>./_art/comic.otf</fontPath>
+      <fontSize>0.016</fontSize>
+  </helpsystem>
 </view>
 
-	
 <view name="basic">
-
-<image name="logo">
-    <path>./_art/logo.png</path>
-</image>
-
-<textlist name="gamelist">
-	<selectorColor>FFFFFFEE</selectorColor>
-	<selectorImagePath>./_art/icon.png</selectorImagePath>
-	<selectedColor>b21212</selectedColor>
-	<selectorHeight>.05</selectorHeight>
-	<primaryColor>EEEEEEEE</primaryColor>
-	<secondaryColor>eac428</secondaryColor>
-	<fontPath>./_art/comic.otf</fontPath>
-	<scrollSound>./_art/scroll_sound.wav</scrollSound>
-	<alignment>left</alignment>
-	<pos>0.04 0.23</pos>
-	<size>0.415 0.674</size>
-	<fontSize>0.022</fontSize>
-	<lineSpacing>1</lineSpacing>
-	<horizontalMargin>0.04</horizontalMargin>
-</textlist>
-
+  <image name="logo">
+      <path>./_art/logo.png</path>
+  </image>
 </view>
 
 <view name="detailed, video">
+  <image name="logo">
+      <path>./_art/logo.png</path>
+  </image>
 
-<image name="logo">
-    <path>./_art/logo.png</path>
-</image>
+  <image name="Help description" extra="trye">
+    <color>FFFFFFEE</color>
+    <path>./_art/help.png</path>
+    <origin>0 0.5</origin>
+    <pos>0.006 0.96</pos>
+    <maxSize>0.478 0.054</maxSize>
+    <zIndex>200</zIndex>
+  </image>
 
-<!--
-<image name="Help marquee" extra="trye">
-	<color>0000FF50</color>
-	<path>./_art/white.png</path>
-	<origin>0 0</origin>
-	<pos>0.53 0.609</pos>
-	<size>0.202 0.09</size>
-	<zIndex>200</zIndex>
-</image>
--->
+  <textlist name="gamelist">
+    <selectorColor>FFFFFFEE</selectorColor>
+    <selectorImagePath>./_art/icon.png</selectorImagePath>
+    <selectedColor>b21212</selectedColor>
+    <selectorHeight>.05</selectorHeight>
+    <primaryColor>EEEEEEEE</primaryColor>
+    <secondaryColor>eac428</secondaryColor>
+    <fontPath>./_art/comic.otf</fontPath>
+    <scrollSound>./_art/scroll_sound.wav</scrollSound>
+    <alignment>left</alignment>
+    <pos>0.04 0.23</pos>
+    <size>0.415 0.674</size>
+    <fontSize>0.022</fontSize>
+    <lineSpacing>1</lineSpacing>
+    <horizontalMargin>0.04</horizontalMargin>
+  </textlist>
 
-<image name="Help description" extra="trye">
-	<color>FFFFFFEE</color>
-	<path>./_art/help.png</path>
-	<origin>0 0.5</origin>
-	<pos>0.006 0.96</pos>
-	<maxSize>0.478 0.054</maxSize>
-	<zIndex>200</zIndex>
-</image>
+  <text name="md_lbl_rating, md_lbl_players, md_lbl_genre, md_lbl_releasedate, md_lbl_playcount, md_lbl_lastplayed, md_lbl_developer, md_lbl_publisher">
+    <color>232323DD</color>
+    <forceUppercase>1</forceUppercase>
+    <fontPath>./_art/comic.otf</fontPath>
+    <fontSize>0.024</fontSize>
+    <size>0.22 0.01</size>
+  </text>
 
-<textlist name="gamelist">
-	<selectorColor>FFFFFFEE</selectorColor>
-	<selectorImagePath>./_art/icon.png</selectorImagePath>
-	<selectedColor>b21212</selectedColor>
-	<selectorHeight>.05</selectorHeight>
-	<primaryColor>EEEEEEEE</primaryColor>
-	<secondaryColor>eac428</secondaryColor>
-	<fontPath>./_art/comic.otf</fontPath>
-	<scrollSound>./_art/scroll_sound.wav</scrollSound>
-	<alignment>left</alignment>
-	<pos>0.04 0.23</pos>
-	<size>0.415 0.674</size>
-	<fontSize>0.022</fontSize>
-	<lineSpacing>1</lineSpacing>
-	<horizontalMargin>0.04</horizontalMargin>
-</textlist>
+  <text name="md_developer, md_publisher, md_genre, md_playcount">
+    <color>232323DD</color>
+    <forceUppercase>1</forceUppercase>
+    <fontPath>./_art/comic.otf</fontPath>
+    <fontSize>0.020</fontSize>
+    <size>0.18 0.02</size>
+  </text>
 
-<text name="md_lbl_rating, md_lbl_players, md_lbl_genre, md_lbl_releasedate, md_lbl_playcount, md_lbl_lastplayed, md_lbl_developer, md_lbl_publisher">
-	<color>232323DD</color>
-	<forceUppercase>1</forceUppercase>
-	<fontPath>./_art/comic.otf</fontPath>
-	<fontSize>0.024</fontSize>
-	<size>0.22 0.01</size>
-</text>
+  <datetime name="md_releasedate, md_lastplayed">
+    <color>232323DD</color>
+    <forceUppercase>1</forceUppercase>
+    <fontPath>./_art/comic.otf</fontPath>
+    <fontSize>0.020</fontSize>
+    <size>0.23 0.02</size>
+  </datetime>
 
-<text name="md_developer, md_publisher, md_genre, md_playcount">
-	<color>232323DD</color>
-	<forceUppercase>1</forceUppercase>
-	<fontPath>./_art/comic.otf</fontPath>
-	<fontSize>0.020</fontSize>
-	<size>0.18 0.02</size>
-</text>
-	
-<datetime name="md_releasedate, md_lastplayed">
-	<color>232323DD</color>
-	<forceUppercase>1</forceUppercase>
-	<fontPath>./_art/comic.otf</fontPath>
-	<fontSize>0.020</fontSize>
-	<size>0.23 0.02</size>
-</datetime>
+  <text name="md_lbl_rating">
+    <color>23232300</color>
+    <pos>0.750 2.455</pos>
+  </text>
 
-<text name="md_lbl_rating">
-	<color>23232300</color>
-	<pos>0.750 2.455</pos>
-</text>
+  <rating name="md_rating">
+    <pos>0.76 0.423</pos>
+    <size>0.7 0.07</size>
+    <filledPath>./_art/full.png</filledPath>
+    <unfilledPath>./_art/empty.png</unfilledPath>
+  </rating>
 
-	<rating name="md_rating">
-	<pos>0.76 0.423</pos>
-	<size>0.7 0.07</size>
-	<filledPath>./_art/full.png</filledPath>
-	<unfilledPath>./_art/empty.png</unfilledPath>
-	</rating>
+  <text name="md_lbl_players">
+    <color>23232300</color>
+    <pos>0.762 1.12</pos>
+  </text>
 
-<text name="md_lbl_players">
-	<color>23232300</color>
-	<pos>0.762 1.12</pos>
-</text>
+  <text name="md_players">
+    <color>232323DD</color>
+    <forceUppercase>1</forceUppercase>
+    <fontPath>./_art/player.ttf</fontPath>
+    <size>0.18 0.02</size>
+    <pos>0.905 0.256</pos>
+    <fontSize>0.05</fontSize>
+  </text>
 
-	<text name="md_players">
-	<color>232323DD</color>
-	<forceUppercase>1</forceUppercase>
-	<fontPath>./_art/player.ttf</fontPath>
-	<size>0.18 0.02</size>
-	<pos>0.905 0.256</pos>
-	<fontSize>0.05</fontSize>
-	</text>
+  <text name="md_lbl_genre">
+    <pos>0.754 0.495</pos>
+  </text>
 
-<text name="md_lbl_genre">
-	<pos>0.754 0.495</pos>
-</text>
+  <text name="md_genre">
+    <pos>0.81 0.488</pos>
+    <size>0.15 0.02</size>
+  </text>
 
-	<text name="md_genre">
-	<pos>0.81 0.488</pos>
-	<size>0.15 0.02</size>
-	</text>
+  <text name="md_lbl_developer">
+    <pos>0.74 2.94</pos>
+  </text>
 
-<text name="md_lbl_developer">
-	<pos>0.74 2.94</pos>
-</text>
-	
-	<text name="md_developer">
-	<pos>0.53 0.936</pos>
-	</text>
+  <text name="md_developer">
+    <pos>0.53 0.936</pos>
+  </text>
 
-<text name="md_lbl_publisher">
-	<pos>0.745 2.30</pos>
-</text>
-	
-	<text name="md_publisher">
-	<pos>0.72 0.936</pos>
-	</text>
+  <text name="md_lbl_publisher">
+    <pos>0.745 2.30</pos>
+  </text>
 
-<text name="md_lbl_releasedate">
-	<pos>0.74 2.36</pos>
-</text>
+  <text name="md_publisher">
+    <pos>0.72 0.936</pos>
+  </text>
 
-	<datetime name="md_releasedate">
-	<pos>0.9 0.936</pos>
-	</datetime>
+  <text name="md_lbl_releasedate">
+    <pos>0.74 2.36</pos>
+  </text>
 
-<text name="md_lbl_playcount">
-	<pos>0.775 0.525</pos>
-</text>
+  <datetime name="md_releasedate">
+    <pos>0.9 0.936</pos>
+  </datetime>
 
-	<text name="md_playcount">
-	<fontPath>./_art/player.ttf</fontPath>
-	<size>0.18 0.02</size>
-	<pos>0.896 0.518</pos>
-	<fontSize>0.0470</fontSize>
-	</text>
-	
-<text name="md_lbl_lastplayed">
-	<pos>0.74 2.48</pos>
-</text>
+  <text name="md_lbl_playcount">
+    <pos>0.775 0.525</pos>
+  </text>
 
-<datetime name="md_lastplayed">
-	<pos>0.75 2.50</pos>
-</datetime>
+  <text name="md_playcount">
+    <fontPath>./_art/player.ttf</fontPath>
+    <size>0.18 0.02</size>
+    <pos>0.896 0.518</pos>
+    <fontSize>0.0470</fontSize>
+  </text>
 
+  <text name="md_lbl_lastplayed">
+    <pos>0.74 2.48</pos>
+  </text>
+
+  <datetime name="md_lastplayed">
+    <pos>0.75 2.50</pos>
+  </datetime>
 </view>
 
 <view name="detailed, video">
-
-<image name="md_image">
-	<origin>.5 .5</origin>
-	<pos>0.6885 0.222</pos>
-	<maxSize>0.317 0.359</maxSize>
-</image>
-
+  <image name="md_image">
+    <origin>.5 .5</origin>
+    <pos>0.6885 0.222</pos>
+    <maxSize>0.317 0.359</maxSize>
+  </image>
 </view>
+
 <!-- Descriptions BEGIN-->
-
 <view name="video">
-<text name="md_description">
-	<pos>0.53 0.700</pos>
-	<size>0.202 0.221</size>
-	<color>232323DD</color>
-	<fontPath>./_art/comic.otf</fontPath>
-	<fontSize>0.022</fontSize>
-	<alignment>left</alignment>
-	<forceUppercase>0</forceUppercase>
-	<lineSpacing>1</lineSpacing>
-</text>
+  <text name="md_description">
+    <pos>0.53 0.700</pos>
+    <size>0.202 0.221</size>
+    <color>232323DD</color>
+    <fontPath>./_art/comic.otf</fontPath>
+    <fontSize>0.022</fontSize>
+    <alignment>left</alignment>
+    <forceUppercase>0</forceUppercase>
+    <lineSpacing>1</lineSpacing>
+  </text>
 </view>
 
 <view name="detailed">
-<text name="md_description">
-	<pos>0.53 0.606</pos>
-	<size>0.2 0.317</size>
-	<color>232323DD</color>
-	<fontPath>./_art/comic.otf</fontPath>
-	<fontSize>0.026</fontSize>
-	<alignment>left</alignment>
-	<forceUppercase>0</forceUppercase>
-	<lineSpacing>1</lineSpacing>
-</text>
+  <text name="md_description">
+    <pos>0.53 0.606</pos>
+    <size>0.2 0.317</size>
+    <color>232323DD</color>
+    <fontPath>./_art/comic.otf</fontPath>
+    <fontSize>0.026</fontSize>
+    <alignment>left</alignment>
+    <forceUppercase>0</forceUppercase>
+    <lineSpacing>1</lineSpacing>
+  </text>
 </view>
 <!-- Descriitions END -->
 
 <feature supported="video">
+  <view name="video">
+    <video name="md_video">
+      <origin>.5 .5</origin>
+      <pos>0.6885 0.222</pos>
+      <maxSize>0.317 0.359</maxSize>
+      <delay>0.5</delay>
+      <showSnapshotNoVideo>true</showSnapshotNoVideo>
+      <showSnapshotDelay>true</showSnapshotDelay>
+    </video>
 
-<view name="video">
-
-<video name="md_video">
-	<origin>.5 .5</origin>
-	<pos>0.6885 0.222</pos>
-	<maxSize>0.317 0.359</maxSize>
-	<delay>0.5</delay>
-	<showSnapshotNoVideo>true</showSnapshotNoVideo>
-	<showSnapshotDelay>true</showSnapshotDelay>
-</video>
-
-<image name="md_marquee">
-	<origin>0 0</origin>
-	<pos>0.53 0.609</pos>
-	<maxSize>0.202 0.09</maxSize>
-</image>
-<!--
-<image name="md_image">
-	<origin>1 1</origin>
-	<pos>.847 0.4</pos>
-	<maxSize>0.2 0.2</maxSize>
-	<zIndex>100</zIndex>
-</image>
--->
-</view>
-
+    <image name="md_marquee">
+      <origin>0 0</origin>
+      <pos>0.53 0.609</pos>
+      <maxSize>0.202 0.09</maxSize>
+    </image>
+  </view>
 </feature>
 
 </theme>

--- a/theme_jp.xml
+++ b/theme_jp.xml
@@ -1,0 +1,56 @@
+<theme>
+<formatVersion>4</formatVersion>
+<include>./theme.xml</include>
+
+<view name="basic, detailed, grid, video">
+  <textlist name="gamelist">
+    <selectorImagePath>./_art/iconj.png</selectorImagePath>
+    <selectedColor>cccccc</selectedColor>
+    <secondaryColor>808080</secondaryColor>
+    <fontPath>./_art/jap.ttf</fontPath>
+    <fontSize>0.028</fontSize>
+    <lineSpacing>1.05</lineSpacing>
+  </textlist>
+
+  <text name="md_description">
+    <fontPath>./_art/jap.ttf</fontPath>
+    <fontSize>0.027</fontSize>
+  </text>
+
+  <text name="md_lbl_rating, md_lbl_players, md_lbl_genre, md_lbl_releasedate, md_lbl_playcount, md_lbl_lastplayed, md_lbl_developer, md_lbl_publisher, md_developer, md_publisher">
+    <fontPath>./_art/jap.ttf</fontPath>
+    <fontSize>0.026</fontSize>
+  </text>
+
+  <text name="md_lbl_genre">
+    <pos>0.754 0.50</pos>
+  </text>
+
+  <text name="md_genre">
+    <fontPath>./_art/jap.ttf</fontPath>
+    <fontSize>0.0235</fontSize>
+    <pos>0.81 0.495</pos>
+  </text>
+
+  <text name="md_playcount">
+    <fontPath>./_art/jap.ttf</fontPath>
+    <fontSize>0.04</fontSize>
+    <pos>0.89 0.518</pos>
+  </text>
+
+  <text name="md_players">
+    <fontPath>./_art/jap.ttf</fontPath>
+    <fontSize>0.05</fontSize>
+    <pos>0.905 0.266</pos>
+  </text>
+
+  <datetime name="md_releasedate, md_lastplayed">
+    <fontPath>./_art/jap.ttf</fontPath>
+    <fontSize>0.026</fontSize>
+  </datetime>
+
+  <rating name="md_rating">
+    <filledPath>./_art/fullj.png</filledPath>
+  </rating>
+</view>
+</theme>

--- a/vectrex/theme.xml
+++ b/vectrex/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/virtualboy/theme.xml
+++ b/virtualboy/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/wonderswan/theme.xml
+++ b/wonderswan/theme.xml
@@ -1,6 +1,6 @@
 <theme>
 	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+	<include>./../theme_jp.xml</include>
 
 <view name="system">
  <image name="background_color" extra="true">
@@ -24,56 +24,6 @@
   <pos>0 0</pos>
   <size>1 1</size>
  </image>
-
-<textlist name="gamelist">
-<selectorImagePath>./../_art/iconj.png</selectorImagePath>
-<selectedColor>cccccc</selectedColor>
-<secondaryColor>808080</secondaryColor>
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.028</fontSize>
-</textlist>
-
-<text name="md_description">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.027</fontSize>
-</text>
-
-<text name="md_lbl_rating, md_lbl_players, md_lbl_genre, md_lbl_releasedate, md_lbl_playcount, md_lbl_lastplayed, md_lbl_developer, md_lbl_publisher, md_developer, md_publisher">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.026</fontSize>
-</text>
-
-<text name="md_lbl_genre">
-	<pos>0.754 0.50</pos>
-</text>
-
-<text name="md_genre">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.0235</fontSize>
-<pos>0.81 0.495</pos>
-</text>
-
-<text name="md_playcount">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.04</fontSize>
-<pos>0.89 0.518</pos>
-</text>
-
-<text name="md_players">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.05</fontSize>
-<pos>0.905 0.266</pos>
-</text>
-
-<datetime name="md_releasedate, md_lastplayed">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.026</fontSize>
-</datetime>
-
-<rating name="md_rating">
-<filledPath>./../_art/fullj.png</filledPath>
-</rating>
-
 </view>
 
 </theme>

--- a/wonderswancolor/theme.xml
+++ b/wonderswancolor/theme.xml
@@ -1,6 +1,6 @@
 <theme>
 	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+	<include>./../theme_jp.xml</include>
 
 <view name="system">
  <image name="background_color" extra="true">
@@ -24,56 +24,6 @@
   <pos>0 0</pos>
   <size>1 1</size>
  </image>
-
-<textlist name="gamelist">
-<selectorImagePath>./../_art/iconj.png</selectorImagePath>
-<selectedColor>cccccc</selectedColor>
-<secondaryColor>808080</secondaryColor>
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.028</fontSize>
-</textlist>
-
-<text name="md_description">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.027</fontSize>
-</text>
-
-<text name="md_lbl_rating, md_lbl_players, md_lbl_genre, md_lbl_releasedate, md_lbl_playcount, md_lbl_lastplayed, md_lbl_developer, md_lbl_publisher, md_developer, md_publisher">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.026</fontSize>
-</text>
-
-<text name="md_lbl_genre">
-	<pos>0.754 0.50</pos>
-</text>
-
-<text name="md_genre">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.0235</fontSize>
-<pos>0.81 0.495</pos>
-</text>
-
-<text name="md_playcount">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.04</fontSize>
-<pos>0.89 0.518</pos>
-</text>
-
-<text name="md_players">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.05</fontSize>
-<pos>0.905 0.266</pos>
-</text>
-
-<datetime name="md_releasedate, md_lastplayed">
-<fontPath>./../_art/jap.ttf</fontPath>
-<fontSize>0.026</fontSize>
-</datetime>
-
-<rating name="md_rating">
-<filledPath>./../_art/fullj.png</filledPath>
-</rating>
-
 </view>
 
 </theme>

--- a/zmachine/theme.xml
+++ b/zmachine/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>

--- a/zxspectrum/theme.xml
+++ b/zxspectrum/theme.xml
@@ -1,29 +1,29 @@
 <theme>
-	<formatVersion>4</formatVersion>
-	<include>./../theme.xml</include>
+<formatVersion>4</formatVersion>
+<include>./../theme.xml</include>
 
 <view name="system">
- <image name="background_color" extra="true">
-  <path>./SLBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./SLBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 <view name="system, basic, detailed, grid, video">
- <image name="logo">
-  <path>./../_art/logo.png</path>
- </image>
+  <image name="logo">
+    <path>./../_art/logo.png</path>
+  </image>
 </view>
 
 <view name="basic, detailed, grid, video">
- <image name="background_color" extra="true">
-  <path>./GMBG.jpg</path>
-  <origin>0 0</origin>
-  <pos>0 0</pos>
-  <size>1 1</size>
- </image>
+  <image name="background_color" extra="true">
+    <path>./GMBG.jpg</path>
+    <origin>0 0</origin>
+    <pos>0 0</pos>
+    <size>1 1</size>
+  </image>
 </view>
 
 </theme>


### PR DESCRIPTION
In addition to making some code improvements for a better readability, I've also created a file for japanese themes, so you do not need to change them one by one. I also corrected some overscan in japanese themes and in Game and Watch. In Game and Watch the problem was the size of the font, because despite using comic.otf it was using the size applied in jap.ttf (0.028). In the case of Japanese themes, it was necessary to add 0.05 of linespacing to remove the overscan, since decreasing the font size the readability becomes compromised.